### PR TITLE
fix(opt-in-asset-if-necessary): Fix if condition

### DIFF
--- a/src/algosdk-missing-types.ts
+++ b/src/algosdk-missing-types.ts
@@ -1,0 +1,22 @@
+export interface AccountAsset {
+  amount: number;
+  "asset-id": number;
+  creator: string;
+  "is-frozen": boolean;
+}
+
+export interface AccountInformationData {
+  address: string;
+  amount: number;
+  "amount-without-pending-rewards": number;
+  "apps-local-state": {id: number, 'key-value': any[]}[];
+  "apps-total-schema": {"num-byte-slice": number; "num-uint": number};
+  assets: AccountAsset[];
+  "created-apps": any[];
+  "created-assets": AccountAsset[];
+  "pending-rewards": number;
+  "reward-base": number;
+  rewards: number;
+  round: number;
+  status: "Offline";
+}

--- a/src/asset-transfer.ts
+++ b/src/asset-transfer.ts
@@ -1,4 +1,5 @@
 import algosdk, { Algodv2 } from "algosdk";
+import { AccountInformationData } from "./algosdk-missing-types";
 import { waitForTransaction } from "./util";
 
 export async function optIntoAssetIfNecessary({
@@ -12,9 +13,9 @@ export async function optIntoAssetIfNecessary({
   initiatorAddr: string;
   initiatorSigner: (txns: any[], index: number) => Promise<Uint8Array>;
 }): Promise<void> {
-  const account = await client.accountInformation(initiatorAddr).do();
+  const account = (await client.accountInformation(initiatorAddr).do()) as AccountInformationData;
 
-  if (!account.assets.some((asset: any) => asset.id === assetID)) {
+  if (!account.assets.some((asset) => asset["asset-id"] === assetID)) {
     const suggestedParams = await client.getTransactionParams().do();
 
     const optInTxn = algosdk.makeAssetTransferTxnWithSuggestedParamsFromObject({

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,8 @@ export {
 export { redeemExcessAsset } from './redeem';
 
 export { applySlippageToAmount } from './util';
+
+export {
+    AccountAsset,
+    AccountInformationData
+} from "./algosdk-missing-types";

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -2,6 +2,7 @@ import assert from 'assert';
 import algosdk from 'algosdk';
 import { waitForTransaction } from './util';
 import { validatorApprovalContract, validatorClearStateContract, VALIDATOR_APP_SCHEMA } from 'algoswap';
+import { AccountInformationData } from './algosdk-missing-types';
 
 
 const CREATE_ENCODED = Uint8Array.from([99, 114, 101, 97, 116, 101]); // 'create'
@@ -125,7 +126,7 @@ export async function isOptedIntoValidator({
     validatorAppID: number,
     initiatorAddr: string,
 }): Promise<boolean> {
-    const info = await client.accountInformation(initiatorAddr).setIntDecoding('mixed').do();
+    const info = (await client.accountInformation(initiatorAddr).setIntDecoding('mixed').do()) as AccountInformationData;
     const appsLocalState = info['apps-local-state'] || [];
 
     for (const app of appsLocalState) {


### PR DESCRIPTION
Due to the missing type information from the algosdk for the accountInformation method, there were some errors within the code that were catched by the compiler after I manually introduced the return type for the accountInformation method:

- The mixing of BigInt and regular numbers in calculations for pool reserves. I coerced numbers into BigInt for these calculations to resolve this.
- `optIntoAssetIfNecessary` were checking against `asset.id` before however it appears the correct property name here is `"asset-id"` instead of just `id`. 