### PR TITLE
Improve swap calculations and quotes

### DIFF
--- a/src/swap.ts
+++ b/src/swap.ts
@@ -5,7 +5,7 @@ import { redeemExcessAsset } from './redeem';
 import { optIntoValidatorIfNecessary } from './validator';
 import { optIntoAssetIfNecessary } from './asset-transfer';
 
-// FEE = %0.03 or 3/1000
+// FEE = %0.3 or 3/1000
 const FEE_NUMERATOR = 3n;
 const FEE_DENOMINATOR = 1000n;
 
@@ -227,7 +227,7 @@ export async function getFixedInputSwapQuote({
     const assetInAmountMinusFee =  assetInAmount - swapFee
     const k = inputSupply * outputSupply
     // k = (inputSupply + assetInAmountMinusFee) * (outputSupply - assetOutAmount)
-    const assetOutAmount = (k / (inputSupply + assetInAmountMinusFee)) - outputSupply;
+    const assetOutAmount =  outputSupply - (k / (inputSupply + assetInAmountMinusFee));
 
     if(assetOutAmount > outputSupply){
         throw new Error('Output amount exceeds available liquidity.');
@@ -404,7 +404,7 @@ export async function getFixedOutputSwapQuote({
     const k = inputSupply * outputSupply
     // k = (inputSupply + assetInAmount) * (outputSupply - assetOutAmount)
     const assetInAmount = (k / (outputSupply - assetOutAmount)) - inputSupply;
-    const swapFee = assetOutAmount * FEE_NUMERATOR / FEE_DENOMINATOR;
+    const swapFee = assetInAmount * FEE_NUMERATOR / FEE_DENOMINATOR;
     const assetInAmountPlusFee = assetInAmount + swapFee;
     const rate = Number(assetOutAmount) / Number(assetInAmountPlusFee);
 


### PR DESCRIPTION
I refactored the `getFixedXSwapQuote` functions to use a simpler and more obvious formula. It is mathematically the same but it this version is much easier to understand (I think).

I have also clarified how the swap fee is calculated. It should always be considered as a fee on the input amount. It doesn't matter if it is a `fixedInput` or `fixedOutput` swap.

I have also included a `rate` field in the `SwapQuote` which represents the exchange rate of the swap in terms of the input asset. e.g. `1 ${inputAsset} = {rate} {outputAsset}`.

I also added basic validation errors if the output amount is > output supply.