### PR TITLE
feat(redeem): Add support to redeem all excess amounts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,8 @@ export {
   getExcessAmounts,
   ExcessAmountData,
   getExcessAmountsWithPoolAssetDetails,
-  ExcessAmountDataWithPoolAssetDetails
+  ExcessAmountDataWithPoolAssetDetails,
+  redeemAllExcessAsset
 } from "./redeem";
 
 export {

--- a/src/util.ts
+++ b/src/util.ts
@@ -243,3 +243,22 @@ function roundNumber({decimalPlaces = 0}, x: number): number {
   // eslint-disable-next-line prefer-template
   return Number(Math.round(Number(x + `e+${decimalPlaces}`)) + `e-${decimalPlaces}`);
 }
+
+/**
+ * @param client - An Algodv2 client.
+ * @param signedTxns - Signed txns to send
+ * @param txnFees - Total transaction fees
+ * @param groupID - Txn Group's ID
+ * @returns Confirmed round and txnID
+ */
+export async function sendAndWaitRawTransaction(client: Algodv2, signedTxns: any[]) {
+  const {txId} = await client.sendRawTransaction(signedTxns).do();
+
+  const status = await waitForTransaction(client, txId);
+  const confirmedRound = status["confirmed-round"];
+
+  return {
+    confirmedRound,
+    txnID: txId
+  };
+}


### PR DESCRIPTION
With this functionality, we require the caller of the util to provide an array of assetIDs and amounts they want to redeem. Within the utility, we generate txn groups for each asset and call `initiatorSigner` for the feeTxns. After txns are signed by the wallet, we send the group of transactions to network individually.