### PR TITLE
feat(transactions): Add signer information to the generated transaction objects

### DIFF
--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -1,4 +1,4 @@
-import algosdk from "algosdk";
+import algosdk, {Transaction} from "algosdk";
 
 export interface AccountAsset {
   amount: number;
@@ -15,5 +15,16 @@ export interface TinymanAnalyticsApiAsset {
   decimals: number;
   url: string;
 }
+export interface SignerTransaction {
+  txn: Transaction;
+  /**
+   * Optional list of addresses that must sign the transactions.
+   * Wallet skips to sign this txn if signers is empty array.
+   * If undefined, wallet tries to sign it.
+   */
+  signers?: string[];
+}
 
-export type InitiatorSigner = (txns: algosdk.Transaction[]) => Promise<Uint8Array[]>;
+export type InitiatorSigner = (
+  txGroupList: SignerTransaction[][]
+) => Promise<Uint8Array[]>;

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1,6 +1,7 @@
+import * as ascJson from "./asc.json";
+
 import {toByteArray} from "base64-js";
 import {makeLogicSig} from "algosdk";
-import * as ascJson from "./asc.json";
 
 const validator_app = ascJson.contracts.validator_app;
 const pool_logicsig = ascJson.contracts.pool_logicsig;
@@ -24,9 +25,13 @@ export const VALIDATOR_APP_SCHEMA = {
 
 export function encodeVarInt(number) {
   let buf: number[] = [];
+
+  // eslint-disable-next-line no-constant-condition
   while (true) {
     let towrite = number & 0x7f;
+
     number >>= 7;
+
     if (number) {
       buf.push(towrite | 0x80);
     } else {
@@ -52,6 +57,7 @@ export function getPoolLogicSig({
 
   if (asset2ID > asset1ID) {
     const tmp = asset1ID;
+
     asset1ID = asset2ID;
     asset2ID = tmp;
   }
@@ -65,6 +71,7 @@ export function getPoolLogicSig({
   };
 
   let offset = 0;
+
   templateVariables.sort((a, b) => a.index - b.index);
   for (let i = 0; i < templateVariables.length; i++) {
     const v = templateVariables[i];
@@ -75,6 +82,7 @@ export function getPoolLogicSig({
     // All of the template variables are ints
     let value_encoded = encodeVarInt(value);
     let diff = v.length - value_encoded.length;
+
     offset += diff;
 
     programArray = programArray
@@ -86,8 +94,15 @@ export function getPoolLogicSig({
   const program = new Uint8Array(programArray);
 
   const lsig = makeLogicSig(program);
+
   return {
     addr: lsig.address(),
     program
   };
 }
+
+/* eslint
+      no-param-reassign: "off",
+      no-bitwise: "off",
+      prefer-destructuring: "off"
+*/

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,8 @@
 export {
   getvalidatorAppID,
-  optIntoValidator,
   generateOptIntoValidatorTxns,
   OPT_IN_VALIDATOR_APP_PROCESS_TXN_COUNT,
   isOptedIntoValidator,
-  optOutOfValidator,
   generateOptOutOfValidatorTxns,
   OPT_OUT_VALIDATOR_APP_PROCESS_TXN_COUNT
 } from "./validator";
@@ -74,7 +72,6 @@ export {
 
 export {
   applySlippageToAmount,
-  optIntoAsset,
   generateOptIntoAssetTxns,
   ASSET_OPT_IN_PROCESS_TXN_COUNT,
   getAssetInformationById,
@@ -85,7 +82,12 @@ export {
   sumUpTxnFees
 } from "./util";
 
-export {AccountAsset, InitiatorSigner, TinymanAnalyticsApiAsset} from "./common-types";
+export {
+  AccountAsset,
+  InitiatorSigner,
+  TinymanAnalyticsApiAsset,
+  SignerTransaction
+} from "./common-types";
 
 export {
   ALGO_ASSET,


### PR DESCRIPTION
- SignerTransaction is now the shape we return from the transaction generator functions.
- signers data is used on the client to determine if the wallet needs to sign that particular transaction.