### PR TITLE
Add support for numbers larger than 2^31-1 such as ASA ID 2155418402

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -302,16 +302,17 @@ export function getTxnGroupID(txns: SignerTransaction[]) {
   return bufferToBase64(txns[0].txn.group);
 }
 
-export function encodeInteger(number) {
+export function encodeInteger(numberIn) {
+  let number = BigInt(numberIn);
   let buf: number[] = [];
 
   /* eslint-disable no-bitwise */
   /* eslint-disable no-constant-condition */
   /* eslint-disable no-param-reassign */
   while (true) {
-    let towrite = number & 0x7f;
+    let towrite = Number(number & BigInt(0x7f));
 
-    number >>= 7;
+    number >>= BigIng(7);
 
     if (number) {
       buf.push(towrite | 0x80);

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -312,7 +312,7 @@ export function encodeInteger(numberIn) {
   while (true) {
     let towrite = Number(number & BigInt(0x7f));
 
-    number >>= BigIng(7);
+    number >>= BigInt(7);
 
     if (number) {
       buf.push(towrite | 0x80);


### PR DESCRIPTION
Add support for numbers larger than 2^31-1 such as ASA ID 2155418402

noticed issue:
![image](https://github.com/tinymanorg/tinyman-js-sdk/assets/87063425/e9c48ff1-759a-453c-a7bd-be14d8b5a61e)

seems to originate here:
![image](https://github.com/tinymanorg/tinyman-js-sdk/assets/87063425/ba3ee7c8-9efd-4a21-9ad3-81fdb26ef948)

Issue is  that 2155418402 >> 7 results in -16715226 while it should not be a negative number!

This results eventually in the array becoming too large:
![image](https://github.com/tinymanorg/tinyman-js-sdk/assets/87063425/358ba812-e28e-4a9a-afe9-c02f720a260d)

To reproduce go to "swap" and then select unverfied asset rugninja and then try and do something, like select Algo for the second asset below.

Using BigInt solves the issue. 

The fix has only very briefly been tested in isolation and is provided just as a starting point for convenience. I have not run any regression pack or anything. 