### PR TITLE
Improve error handling of `getRawBoxValue`

### DIFF
--- a/src/governance/utils.ts
+++ b/src/governance/utils.ts
@@ -39,9 +39,7 @@ async function getRawBoxValue(
 
     return value;
   } catch (error: any) {
-    if (
-      error.message === "Network request error. Received status 404 (): box not found"
-    ) {
+    if (error.message.includes("box not found")) {
       return null;
     }
 


### PR DESCRIPTION
- Return `null` if part of the error message includes "box not found" message